### PR TITLE
Use Helper logging in AbstractNodeCostSearch

### DIFF
--- a/src/main/java/baritone/pathing/calc/AbstractNodeCostSearch.java
+++ b/src/main/java/baritone/pathing/calc/AbstractNodeCostSearch.java
@@ -203,11 +203,11 @@ public abstract class AbstractNodeCostSearch implements IPathFinder, Helper {
             if (dist > MIN_DIST_PATH * MIN_DIST_PATH) { // square the comparison since distFromStartSq is squared
                 if (logInfo) {
                     if (COEFFICIENTS[i] >= 3) {
-                        System.out.println("Warning: cost coefficient is greater than three! Probably means that");
-                        System.out.println("the path I found is pretty terrible (like sneak-bridging for dozens of blocks)");
-                        System.out.println("But I'm going to do it anyway, because yolo");
+                        logDirect("Warning: cost coefficient is greater than three! Probably means that");
+                        logDirect("the path I found is pretty terrible (like sneak-bridging for dozens of blocks)");
+                        logDirect("But I'm going to do it anyway, because yolo");
                     }
-                    System.out.println("Path goes for " + Math.sqrt(dist) + " blocks");
+                    logDebug("Path goes for " + Math.sqrt(dist) + " blocks");
                     logDebug("A* cost coefficient " + COEFFICIENTS[i]);
                 }
                 return Optional.of(new Path(realStart, startNode, bestSoFar[i], numNodes, goal, context));


### PR DESCRIPTION
## Summary
- switch System.out.println usage in `AbstractNodeCostSearch` to use `Helper` logging

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686a9f235a1c8328a39133ff7698b68b