### PR TITLE
Use logDebug in GetToBlockProcess

### DIFF
--- a/src/main/java/baritone/process/GetToBlockProcess.java
+++ b/src/main/java/baritone/process/GetToBlockProcess.java
@@ -216,7 +216,7 @@ public final class GetToBlockProcess extends BaritoneProcessHelper implements IG
                 baritone.getLookBehavior().updateTarget(reachable.get(), true);
                 if (knownLocations.contains(ctx.getSelectedBlock().orElse(null))) {
                     baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true); // TODO find some way to right click even if we're in an ESC menu
-                    System.out.println(ctx.player().containerMenu);
+                    logDebug(String.valueOf(ctx.player().containerMenu));
                     if (!(ctx.player().containerMenu instanceof InventoryMenu)) {
                         return true;
                     }


### PR DESCRIPTION
## Summary
- replace a leftover `System.out.println` with `logDebug`

## Testing
- `./gradlew test` *(fails: Failed to create Jar file)*

------
https://chatgpt.com/codex/tasks/task_e_686a9f21055c8328acfe0e85e47654eb