### PR TITLE
Populate commandUsage list in suggestion helper

### DIFF
--- a/src/launch/java/baritone/launch/mixins/MixinCommandSuggestionHelper.java
+++ b/src/launch/java/baritone/launch/mixins/MixinCommandSuggestionHelper.java
@@ -92,8 +92,21 @@ public class MixinCommandSuggestionHelper {
 
             this.input.setSuggestion(null); // clear old suggestions
             this.suggestions = null;
-            // TODO: Support populating the command usage
+            // Populate commandUsage so that the suggestion window shows some
+            // contextual hint text. Minecraft normally fills this list with
+            // usage information derived from the parse results. When we
+            // short-circuit the command suggestions pipeline we lose that
+            // information, so instead show a simple explanation of the
+            // available completions.
             this.commandUsage.clear();
+            if (event.completions.length == 0) {
+                this.commandUsage.add("No completions available");
+            } else {
+                this.commandUsage.add("Possible completions:");
+                for (String comp : event.completions) {
+                    this.commandUsage.add("  " + comp);
+                }
+            }
 
             if (event.completions.length == 0) {
                 this.pendingSuggestions = Suggestions.empty();


### PR DESCRIPTION
## Summary
- show simple usage help when Baritone's TabCompleteEvent overrides suggestions

## Testing
- `./gradlew test` *(fails: Failed to create Jar file)*

------
https://chatgpt.com/codex/tasks/task_e_686d337a220c83289ec4b0c2774210a6